### PR TITLE
feat- warning if cropped image crosses word region

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -232,6 +232,10 @@ def crop_img(img, vertices, labels, length):
         start_w = int(np.random.rand() * remain_w)
         start_h = int(np.random.rand() * remain_h)
         flag = is_cross_text([start_w, start_h], length, new_vertices[labels==1,:])
+    
+    if flag:
+        print('WARNING! Cropped image crosses word regions!')
+
     box = (start_w, start_h, start_w + length, start_h + length)
     region = img.crop(box)
     if new_vertices.size == 0:


### PR DESCRIPTION
현재 image crop 시 random crop을 1000번 시도해도 word region과 겹치는 cropped image를 만들지 못하면 그냥 word region과 겹치면서 cropped image를 생성합니다.  

이러한 경우를 알기 위해 text region을 겹쳐 cropped image를 만들 때 warning message가 출력되는 코드를 추가했습니다.

만약 warning 이 너무 많이 출력된다면 시도 횟수를 1000에서 더 늘릴 필요가 있을 것 같습니다.